### PR TITLE
Avoid to materialize cleartext password (based on Servox3 pull request)

### DIFF
--- a/src/Simple.CredentialManager/Credential.cs
+++ b/src/Simple.CredentialManager/Credential.cs
@@ -350,16 +350,15 @@ namespace Simple.CredentialManager
             CheckNotDisposed();
             UnmanagedCodePermission.Demand();
 
-            var passwordBytes = Encoding.Unicode.GetBytes(Password);
-            if (Password.Length > (512))
+            if (SecurePassword.Length * sizeof(char) > (512))
                 throw new ArgumentOutOfRangeException("password", "The password has exceeded 512 bytes.");
 
             var credential = new NativeMethods.CREDENTIAL
             {
                 TargetName = Target,
                 UserName = Username,
-                CredentialBlob = Marshal.StringToCoTaskMemUni(Password),
-                CredentialBlobSize = passwordBytes.Length,
+                CredentialBlob = Marshal.SecureStringToGlobalAllocUnicode(SecurePassword),
+                CredentialBlobSize = SecurePassword.Length * sizeof(char),
                 Comment = Description,
                 Type = (int) Type,
                 Persist = (int) PersistenceType
@@ -457,7 +456,10 @@ namespace Simple.CredentialManager
 
             if (credential.CredentialBlobSize > 0)
             {
-                Password = Marshal.PtrToStringUni(credential.CredentialBlob, credential.CredentialBlobSize/2);
+                unsafe
+                {
+                    SecurePassword = new SecureString((char*)credential.CredentialBlob.ToPointer(), credential.CredentialBlobSize / sizeof(char));
+                }
             }
 
             Target = credential.TargetName;


### PR DESCRIPTION
It is basically the same as [Servox3 pull request](https://github.com/spolnik/Simple.CredentialsManager/pull/3), but with the boundary check introduced from @spolnik 
This pull request based on the discussion in the mentioned pull request. All credits to Servox3 - but I think, the boundary check is important. 