### PR TITLE
Added back support for .NET versions lower than 8.0

### DIFF
--- a/src/Simple.CredentialManager/Simple.CredentialManager.csproj
+++ b/src/Simple.CredentialManager/Simple.CredentialManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>Simple.CredentialManager</AssemblyTitle>

--- a/src/Simple.CredentialManager/Simple.CredentialManager.csproj
+++ b/src/Simple.CredentialManager/Simple.CredentialManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>Simple.CredentialManager</AssemblyTitle>
@@ -10,35 +10,9 @@
     <Copyright>Copyright ©  2014</Copyright>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RegisterForComInterop>false</RegisterForComInterop>
-    <DocumentationFile>bin\Debug\Simple.CredentialManager.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <DocumentationFile>bin\Release\Simple.CredentialManager.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CodeAnalysisLogFile>bin\Debug\WindowsCredentialsManagement.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <CodeAnalysisLogFile>bin\Release\WindowsCredentialsManagement.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="7.0.0" />

--- a/src/Simple.CredentialManager/Simple.CredentialManager.csproj
+++ b/src/Simple.CredentialManager/Simple.CredentialManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>Simple.CredentialManager</AssemblyTitle>

--- a/src/Simple.CredentialManager/secrets.DBus.cs
+++ b/src/Simple.CredentialManager/secrets.DBus.cs
@@ -8,7 +8,7 @@ using Tmds.DBus;
 [assembly: InternalsVisibleTo(Tmds.DBus.Connection.DynamicAssemblyName)]
 namespace secrets.DBus
 {
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     [DBusInterface("org.gnome.keyring.InternalUnsupportedGuiltRiddenInterface")]
@@ -20,7 +20,7 @@ namespace secrets.DBus
         Task UnlockWithMasterPasswordAsync(ObjectPath Collection, (ObjectPath, byte[], byte[], string) Master);
     }
 
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     [DBusInterface("org.freedesktop.Secret.Service")]
@@ -74,7 +74,7 @@ namespace secrets.DBus
         public static Task<ObjectPath[]> GetCollectionsAsync(this IService o) => o.GetAsync<ObjectPath[]>("Collections");
     }
 
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     [DBusInterface("org.freedesktop.Secret.Collection")]
@@ -183,7 +183,7 @@ namespace secrets.DBus
     }
 
     [DBusInterface("org.freedesktop.Secret.Item")]
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     interface IItem : IDBusObject
@@ -305,7 +305,7 @@ namespace secrets.DBus
     }
 
     [DBusInterface("org.freedesktop.Secret.Session")]
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     interface ISession : IDBusObject
@@ -314,7 +314,7 @@ namespace secrets.DBus
     }
 
     [DBusInterface("org.freedesktop.Secret.Prompt")]
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     interface IPrompt : IDBusObject
@@ -325,7 +325,7 @@ namespace secrets.DBus
     }
 
     [DBusInterface("org.freedesktop.impl.portal.Secret")]
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     interface ISecret : IDBusObject
@@ -367,7 +367,7 @@ namespace secrets.DBus
     }
 
     [DBusInterface("org.gnome.keyring.Daemon")]
-#if NET5_0_OR_GREATER
+#if NET6_0_OR_GREATER
     [SupportedOSPlatform("Linux")]
 #endif
     interface IDaemon : IDBusObject


### PR DESCRIPTION
Project was moved to net8.0 in commit aac8047d3428246394d1fc47a56be8c6af6c553d.
Because of that it's no longer possible to reference this project at all in .NET versions lower than 8.0 which also include .NET Framework.
This PR changes net8.0 target framework to .NET Standard 2.0, .NET 5.0 and .NET 6.0 to support other frameworks without losing functionality. 
Supported versions:
* .NET Standard 2.0: .NET Framework + .NET Core < 5.0
* .NET 5.0: .NET Core 5.0
* .NET 6.0: .NET Core 6.0+
Versions 5.0 and 6.0 had to be separated to support _**SupportedOSPlatform**_ attribute on interfaces (which .NET 5.0 doesn't support).